### PR TITLE
Port number to respect forwarded proto

### DIFF
--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -79,9 +79,11 @@ defmodule PlugCanonicalHost do
 
   @spec canonical_port(%Conn{}) :: binary | integer
   defp canonical_port(conn = %Conn{port: port}) do
-    case get_req_header(conn, @forwarded_port_header) do
-      [forwarded_port] -> forwarded_port
-      [] -> port
+    case {get_req_header(conn, @forwarded_port_header), get_req_header(conn, @forwarded_proto_header)} do
+      {[forwarded_port], _} -> forwarded_port
+      {[], ["http"]} -> 80
+      {[], ["https"]} -> 443
+      {[], []} -> port
     end
   end
 

--- a/test/plug_canonical_host_test.exs
+++ b/test/plug_canonical_host_test.exs
@@ -67,6 +67,17 @@ defmodule PlugCanonicalHostTest do
     assert get_resp_header(conn, "location") === ["https://example.com/foo?bar=1"]
   end
 
+  test "redirects to forwarded proto without forwarded port" do
+    conn =
+      :get
+      |> conn("http://www.example.com/foo?bar=1")
+      |> put_req_header("x-forwarded-proto", "https")
+      |> TestApp.call(TestApp.init([]))
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") === ["https://example.com/foo?bar=1"]
+  end
+
   test "does not redirect to canonical host when already on canonical host" do
     conn =
       :get


### PR DESCRIPTION
Thank you for your nice plug.

I'm using gigalixir, PaaS for elixir. That service supports SSL and adds `x-forwarded-proto` header, but does not add `x-forwarded-port` header.
In this case, `http://www.example/` is unexpectedly redirected to `https://example:80/`.

This PR modifies how to determine port number when `x-forwarded-proto` exists but `x-forwarded-port` does not.