### PR TITLE
Remove “ignore” option

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2019 Rémi Prévost
+Copyright (c) 2016-2020 Rémi Prévost
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Then run `mix do deps.get, deps.compile` inside your project’s directory.
 
 ## Usage
 
-`PlugCanonicalHost` can be used just as any other plugs. Add `PlugCanonicalHost` before all of the other plugs you want to happen after successful redirection to your canonical host.
+`PlugCanonicalHost` can be used just as any other plugs. Add `PlugCanonicalHost` before all of the other plugs you want to happen after successful redirect to your canonical host.
 
 The recommended way to define a canonical host is with an environment variable.
 
 ```elixir
-# config/config.exs
+# config/releases.exs
 config :my_app,
   canonical_host: System.get_env("CANONICAL_HOST")
 
@@ -52,7 +52,7 @@ defmodule MyApp.Endpoint do
 end
 ```
 
-For example, if your application is accessible via both `example.com` and `www.example.com`, all traffic coming through `example.com` will be redirected (with a `301` HTTP status) to the matching `www.example.com` URL.
+For example, if your `CANONICAL_HOST` is `www.example.com` but your application is accessible via both `example.com` and `www.example.com`, all traffic coming through `example.com` will be redirected (with a `301` HTTP status) to the matching `www.example.com` URL.
 
 ```bash
 $ curl -sI "http://example.com/foo?bar=1"
@@ -60,8 +60,44 @@ $ curl -sI "http://example.com/foo?bar=1"
 #> Location: http://www.example.com/foo?bar=1
 ```
 
+If you want to _exclude_ certain requests from redirecting to the canonical host, you can use simple pattern matching in your function arguments:
+
+```elixir
+defmodule MyApp.Endpoint do
+  import Plug.Conn
+
+  plug(:canonical_host)
+
+  defp canonical_host(%Conn{path: "/no-canonical-host-redirect"} = conn), do: send_resp(conn, 200, "👋")
+
+  defp canonical_host(conn, _opts) do
+    :my_app
+    |> Application.get_env(:canonical_host)
+    |> case do
+      host when is_binary(host) ->
+        opts = PlugCanonicalHost.init(canonical_host: host)
+        PlugCanonicalHost.call(conn, opts)
+
+      _ ->
+        conn
+    end
+  end
+end
+```
+
+Now, all requests going to the `/no-canonical-host-redirect` path will skip the canonical host redirect behavior.
+
+```bash
+$ curl -sI "http://example.com/foo?bar=1"
+#> HTTP/1.1 301 Moved Permanently
+#> Location: http://www.example.com/foo?bar=1
+
+$ curl -sI "http://example.com/no-canonical-host-redirect"
+#> HTTP/1.1 200 OK
+```
+
 ## License
 
-`PlugCanonicalHost` is © 2016-2019 [Rémi Prévost](http://exomel.com) and may be freely distributed under the [MIT license](https://github.com/remi/plug_canonical_host/blob/master/LICENSE.md). See the `LICENSE.md` file for more information.
+`PlugCanonicalHost` is © 2016-2020 [Rémi Prévost](http://exomel.com) and may be freely distributed under the [MIT license](https://github.com/remi/plug_canonical_host/blob/master/LICENSE.md). See the `LICENSE.md` file for more information.
 
 The plug logo is based on [this lovely icon by Vectors Market](https://thenounproject.com/term/usb-plug/298582), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.

--- a/README.md
+++ b/README.md
@@ -60,33 +60,6 @@ $ curl -sI "http://example.com/foo?bar=1"
 #> Location: http://www.example.com/foo?bar=1
 ```
 
-You can also specify requests to ignore (ie. that will pass through without redirecting to the canonical host).
-
-```elixir
-opts = PlugCanonicalHost.init(
-  canonical_host: host,
-  ignore: fn(%Conn{host: request_host}) ->
-    # The argument is a `Plug.Conn` struct, which means we
-    # can match on dozen of other fields (headers, query, etc.)
-    #
-    # Reference: https://hexdocs.pm/plug/Plug.Conn.html
-
-    request_host in ["www.example.org"]
-  end
-)
-```
-
-Assuming `example.com`, `www.example.com` and `www.example.org` all point to our application:
-
-```bash
-$ curl -sI "http://example.com/foo?bar=1"
-#> HTTP/1.1 301 Moved Permanently
-#> Location: http://www.example.com/foo?bar=1
-
-$ curl -sI "http://www.example.org/foo?bar=1"
-#> HTTP/1.1 200 OK
-```
-
 ## License
 
 `PlugCanonicalHost` is © 2016-2019 [Rémi Prévost](http://exomel.com) and may be freely distributed under the [MIT license](https://github.com/remi/plug_canonical_host/blob/master/LICENSE.md). See the `LICENSE.md` file for more information.

--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -37,8 +37,7 @@ defmodule PlugCanonicalHost do
   @spec init(opts) :: opts
   def init(opts) do
     [
-      canonical_host: Keyword.fetch!(opts, :canonical_host),
-      ignore: Keyword.get(opts, :ignore, fn _ -> false end)
+      canonical_host: Keyword.fetch!(opts, :canonical_host)
     ]
   end
 
@@ -46,18 +45,14 @@ defmodule PlugCanonicalHost do
   Call the plug.
   """
   @spec call(%Conn{}, opts) :: Conn.t()
-  def call(conn = %Conn{host: host}, canonical_host: canonical_host, ignore: ignore)
+  def call(conn = %Conn{host: host}, canonical_host: canonical_host)
       when is_nil(canonical_host) == false and canonical_host !== "" and host !== canonical_host do
-    if ignore.(conn) do
-      conn
-    else
-      location = conn |> redirect_location(canonical_host)
+    location = conn |> redirect_location(canonical_host)
 
-      conn
-      |> put_resp_header(@location_header, location)
-      |> send_resp(@status_code, String.replace(@html_template, "%s", location))
-      |> halt
-    end
+    conn
+    |> put_resp_header(@location_header, location)
+    |> send_resp(@status_code, String.replace(@html_template, "%s", location))
+    |> halt
   end
 
   def call(conn, _), do: conn


### PR DESCRIPTION
I realized that the `ignore` option is pretty useless. Because instead of doing this:

```elixir
plug(:canonical_host)

def canonical_host(conn) do
  opts = PlugCanonicalHost.init(
    canonical_host: host,
    ignore: fn(%Conn{host: host}) -> host in ["www.example.org"] end
  )
  
  PlugCanonicalHost.call(conn, opts)
end
```

you can simply do this:

```elixir
plug(:canonical_host)

def canonical_host(%Conn{host: host} = conn) when host in ["www.example.org"], do: conn

def canonical_host(conn) do
  opts = PlugCanonicalHost.init(canonical_host: host)
  PlugCanonicalHost.call(conn, opts)
end
```

The behavior will exactly be the same — no need for an `ignore` option!