### PR TITLE
Improve CI and Publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
       - run: make plts
       - run: make lint
       - run: make test
+      - run: mix hex.publish --dry-run
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 23.x
-          elixir-version: 1.11.x
+          otp-version: 24.x
+          elixir-version: 1.12.x
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes


### PR DESCRIPTION
A few maintenance tasks in our GitHub Actions workflows:

* Add `mix hex.publish --dry-run` as a CI step
* Update OTP/Elixir version for the publish workflow